### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/fawazahmed0/774ef203-dd54-4162-a13d-a63efdbef1b2/3fbf715f-4236-401e-9ab7-bda52a3338c5/_apis/work/boardbadge/d1eebfca-dbbf-4305-a7fc-9a7b1253f1ff)](https://dev.azure.com/fawazahmed0/774ef203-dd54-4162-a13d-a63efdbef1b2/_boards/board/t/3fbf715f-4236-401e-9ab7-bda52a3338c5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/fawazahmed0/774ef203-dd54-4162-a13d-a63efdbef1b2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.